### PR TITLE
Docker registry url changes

### DIFF
--- a/deploy/tilt/dependencies/registry/Tiltfile
+++ b/deploy/tilt/dependencies/registry/Tiltfile
@@ -45,7 +45,7 @@ def deploy_registry(name='docker-registry', user='user', password="", url="", ip
     helm_remote(
         'docker-registry',
         release_name=name,
-        repo_url='https://kubernetes-charts.storage.googleapis.com/',
+        repo_url='https://charts.helm.sh/stable',
         repo_name='docker-registry',
         set=set_values,
     )


### PR DESCRIPTION
With reference to below error, proposing the change to update the URL 

```#  helm repo add docker-registry https://kubernetes-charts.storage.googleapis.com/
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
```